### PR TITLE
Adding parameter '-urls ' and commands:  'rmdir ' and 'mkdir '

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 *.iml
+etcdsh

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Although there is an official command line tool [etcdctl](https://github.com/cor
 <code>/foo/bar> set key value</code>
 <code>/foo/bar> get key</code>
 <code>value</code>
-<code>dump /</code>
+<code>/foo/bar> dump /</code>
 <code>/foo/</code>
 <code>/foo/bar/</code>
 <code>/foo/bar/key#value</code>

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ Although there is an official command line tool [etcdctl](https://github.com/cor
 <code>dir2</code>
 <code>dir3</code>
 <code>/foo/bar> rmdir dir3</code>
+<code>/foo/bar> cd ..</code>
+<code>/foo> ls</code>
+<code>bar</code>
+<code>/foo> cp bar xyz</code>
+<code>/foo> ls</code>
+<code>bar</code>
+<code>xyz</code>
+<code>/foo> mv xyz aaa</code>
+<code>/foo> ls</code>
+<code>bar</code>
+<code>aaa</code>
 <code>/foo/bar> exit</code>
 </pre>
 

--- a/README.md
+++ b/README.md
@@ -15,16 +15,22 @@ Although there is an official command line tool [etcdctl](https://github.com/cor
 
 ## Examples
 <pre>
-<code>./etcdsh --url http://localhost:4001</code>
-<code>connected to etcd 2.0.0</code>
+<code>./etcdsh [-url http://localhost:4001] [-urls http://etcd1:4001,http://etcd2:4001]</code>
+<code>connected to etcd</code>
 <code>/>cd foo/bar</code>
-<code>/foo/bar>ls</code>
-<code>dir1</code>
-<code>dir2</code>
 <code>/foo/bar>set key value</code>
 <code>/foo/bar>get key</code>
 <code>value</code>
 <code>/foo/bar>rm key</code>
+<code>/foo/bar>ls</code>
+<code>dir1</code>
+<code>dir2</code>
+<code>/foo/bar>mkdir xyz</code>
+<code>/foo/bar>ls</code>
+<code>dir1</code>
+<code>dir2</code>
+<code>xyz</code>
+<code>/foo/bar>rmdir xyz</code>
 <code>/foo/bar>exit</code>
 </pre>
 

--- a/README.md
+++ b/README.md
@@ -15,22 +15,28 @@ Although there is an official command line tool [etcdctl](https://github.com/cor
 
 ## Examples
 <pre>
-<code>./etcdsh [-url http://localhost:4001] [-urls http://etcd1:4001,http://etcd2:4001]</code>
+<code>./etcdsh [--url http://localhost:4001] [--urls http://etcd1:4001,http://etcd2:4001]</code>
 <code>connected to etcd</code>
-<code>/>cd foo/bar</code>
-<code>/foo/bar>set key value</code>
-<code>/foo/bar>get key</code>
+<code>/> cd foo/bar</code>
+<code>/foo/bar> set key value</code>
+<code>/foo/bar> get key</code>
 <code>value</code>
-<code>/foo/bar>rm key</code>
-<code>/foo/bar>ls</code>
+<code>dump /</code>
+<code>/foo/</code>
+<code>/foo/bar/</code>
+<code>/foo/bar/key#value</code>
+<code>/foo/bar/dir1/</code>
+<code>/foo/bar/dir2/</code>
+<code>/foo/bar> rm key</code>
+<code>/foo/bar> ls</code>
 <code>dir1</code>
 <code>dir2</code>
-<code>/foo/bar>mkdir xyz</code>
-<code>/foo/bar>ls</code>
+<code>/foo/bar> mkdir dir3</code>
+<code>/foo/bar> ls</code>
 <code>dir1</code>
 <code>dir2</code>
-<code>xyz</code>
-<code>/foo/bar>rmdir xyz</code>
-<code>/foo/bar>exit</code>
+<code>dir3</code>
+<code>/foo/bar> rmdir dir3</code>
+<code>/foo/bar> exit</code>
 </pre>
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,17 +1,18 @@
 package cli
 
-import "flag"
-import "fmt"
-import "strings"
-import "log"
-import "github.com/kamilhark/etcdsh/commands"
-import "github.com/kamilhark/etcdsh/pathresolver"
-
 import (
+	"flag"
+	"fmt"
+	"log"
+	"strings"
 	"time"
 
 	"github.com/coreos/etcd/client"
 	"github.com/peterh/liner"
+
+	"github.com/kamilhark/etcdsh/commands"
+	"github.com/kamilhark/etcdsh/engine"
+	"github.com/kamilhark/etcdsh/pathresolver"
 )
 
 func Start() {
@@ -54,16 +55,21 @@ func Start() {
 
 	console := liner.NewLiner()
 	console.SetTabCompletionStyle(liner.TabCircular)
+
+	engine := engine.Engine{PathResolver: pathResolver, KeysApi: api}
+
 	commandsArray := []commands.Command{
 		&commands.ExitCommand{State: console},
-		&commands.CdCommand{PathResolver: pathResolver, KeysApi: api},
-		&commands.LsCommand{PathResolver: pathResolver, KeysApi: api},
-		&commands.DumpCommand{PathResolver: pathResolver, KeysApi: api},
-		&commands.GetCommand{PathResolver: pathResolver, KeysApi: api},
-		&commands.SetCommand{PathResolver: pathResolver, KeysApi: api},
-		&commands.RmCommand{PathResolver: pathResolver, KeysApi: api},
-		&commands.RmDirCommand{PathResolver: pathResolver, KeysApi: api},
-		&commands.MkDirCommand{PathResolver: pathResolver, KeysApi: api},
+		&commands.CdCommand{Engine: engine},
+		&commands.CpCommand{Engine: engine},
+		&commands.LsCommand{Engine: engine},
+		&commands.MvCommand{Engine: engine},
+		&commands.DumpCommand{Engine: engine},
+		&commands.GetCommand{Engine: engine},
+		&commands.SetCommand{Engine: engine},
+		&commands.RmCommand{Engine: engine},
+		&commands.RmDirCommand{Engine: engine},
+		&commands.MkDirCommand{Engine: engine},
 	}
 
 	defer console.Close()

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -8,17 +8,18 @@ import "github.com/kamilhark/etcdsh/commands"
 import "github.com/kamilhark/etcdsh/pathresolver"
 
 import (
-	"github.com/peterh/liner"
-	"github.com/coreos/etcd/client"
 	"time"
+
+	"github.com/coreos/etcd/client"
+	"github.com/peterh/liner"
 )
 
 func Start() {
 
- 	var urls = flag.String("urls", "", "etcd urls")
-        var url = flag.String("url", "", "etcd url")
+	var urls = flag.String("urls", "", "etcd urls")
+	var url = flag.String("url", "", "etcd url")
 
-	flag.Parse()	
+	flag.Parse()
 
 	etcdUrls := strings.Split(*urls, ",")
 	etcdUrl := *url
@@ -26,9 +27,9 @@ func Start() {
 	if etcdUrl != "" {
 		if *urls != "" {
 			log.Fatal("You must enter --url or --urls")
-		}else{
+		} else {
 			etcdUrls = []string{etcdUrl}
-		}		
+		}
 	}
 
 	if len(etcdUrls) == 1 && etcdUrls[0] == "" {
@@ -37,8 +38,8 @@ func Start() {
 
 	pathResolver := new(pathresolver.PathResolver)
 	cfg := client.Config{
-		Endpoints:               etcdUrls,
-		Transport:               client.DefaultTransport,
+		Endpoints: etcdUrls,
+		Transport: client.DefaultTransport,
 		// set timeout per request to fail fast when the target endpoint is unavailable
 		HeaderTimeoutPerRequest: time.Second,
 	}
@@ -57,6 +58,7 @@ func Start() {
 		&commands.ExitCommand{State: console},
 		&commands.CdCommand{PathResolver: pathResolver, KeysApi: api},
 		&commands.LsCommand{PathResolver: pathResolver, KeysApi: api},
+		&commands.DumpCommand{PathResolver: pathResolver, KeysApi: api},
 		&commands.GetCommand{PathResolver: pathResolver, KeysApi: api},
 		&commands.SetCommand{PathResolver: pathResolver, KeysApi: api},
 		&commands.RmCommand{PathResolver: pathResolver, KeysApi: api},

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -70,7 +70,7 @@ func Start() {
 	console.SetCompleter(completer)
 
 	for {
-		line, err := console.Prompt(pathResolver.CurrentPath() + ">")
+		line, err := console.Prompt(pathResolver.CurrentPath() + "> ")
 
 		if err != nil && err == liner.ErrPromptAborted {
 			return

--- a/cli/completer.go
+++ b/cli/completer.go
@@ -1,11 +1,11 @@
 package cli
 
 import (
-	"strings"
+	"github.com/coreos/etcd/client"
 	"github.com/kamilhark/etcdsh/commands"
 	"github.com/kamilhark/etcdsh/pathresolver"
-	"github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
+	"strings"
 )
 
 type Completer struct {
@@ -29,7 +29,6 @@ func (c *Completer) Get(line string) []string {
 	return []string{}
 }
 
-
 func (c *Completer) completeCommand(tokens []string) (result []string) {
 	for _, commandHandler := range c.CommandsArray {
 		if strings.HasPrefix(commandHandler.CommandString(), tokens[0]) {
@@ -42,7 +41,7 @@ func (c *Completer) completeCommand(tokens []string) (result []string) {
 func (c *Completer) completeArgument(line string, tokens []string) (result []string) {
 
 	commandHandler := c.getCommandHandler(line)
-	if (commandHandler == nil || !commandHandler.GetAutoCompleteConfig().Available) {
+	if commandHandler == nil || !commandHandler.GetAutoCompleteConfig().Available {
 		return
 	}
 
@@ -53,9 +52,9 @@ func (c *Completer) completeArgument(line string, tokens []string) (result []str
 
 	for _, node := range nodes {
 		lastIndexOfSlash := strings.LastIndex(node.Key, "/")
-		key := node.Key[lastIndexOfSlash + 1:]
+		key := node.Key[lastIndexOfSlash+1:]
 		if strings.HasPrefix(key, tokens[1]) && (node.Dir || !autoCompleteConfig.OnlyDirs) {
-			result = append(result, commandHandler.CommandString() + " " + key)
+			result = append(result, commandHandler.CommandString()+" "+key)
 		}
 	}
 

--- a/cli/completer_test.go
+++ b/cli/completer_test.go
@@ -15,6 +15,7 @@ var pathResolver = &pathresolver.PathResolver{}
 var commandsArray = []commands.Command{
 	&commands.CdCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
 	&commands.LsCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
+	&commands.DumpCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
 	&commands.GetCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
 	&commands.SetCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
 	&commands.RmCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
@@ -26,6 +27,7 @@ var completer = (&Completer{keysApiMock, commandsArray, pathResolver}).Get
 
 func TestCompleteCommandsNames(t *testing.T) {
 	assertContainHint(t, completer("c"), "cd")
+	assertContainHint(t, completer("d"), "dump")
 	assertContainHint(t, completer("s"), "set")
 	assertContainHint(t, completer("r"), "rm")
 	assertContainHint(t, completer("l"), "ls")

--- a/cli/completer_test.go
+++ b/cli/completer_test.go
@@ -6,27 +6,31 @@ import (
 
 	"github.com/coreos/etcd/client"
 	"github.com/kamilhark/etcdsh/commands"
+	"github.com/kamilhark/etcdsh/engine"
 	"github.com/kamilhark/etcdsh/mocks"
 	"github.com/kamilhark/etcdsh/pathresolver"
 )
 
 var keysApiMock = mocks.NewKeysApiMock()
 var pathResolver = &pathresolver.PathResolver{}
+var Engine = engine.Engine{PathResolver: pathResolver, KeysApi: keysApiMock}
+
 var commandsArray = []commands.Command{
-	&commands.CdCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
-	&commands.LsCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
-	&commands.DumpCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
-	&commands.GetCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
-	&commands.SetCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
-	&commands.RmCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
-	&commands.RmDirCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
-	&commands.MkDirCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
+	&commands.CdCommand{Engine: Engine},
+	&commands.LsCommand{Engine: Engine},
+	&commands.DumpCommand{Engine: Engine},
+	&commands.GetCommand{Engine: Engine},
+	&commands.SetCommand{Engine: Engine},
+	&commands.RmCommand{Engine: Engine},
+	&commands.RmDirCommand{Engine: Engine},
+	&commands.MkDirCommand{Engine: Engine},
 	&commands.ExitCommand{},
 }
 var completer = (&Completer{keysApiMock, commandsArray, pathResolver}).Get
 
 func TestCompleteCommandsNames(t *testing.T) {
 	assertContainHint(t, completer("c"), "cd")
+	assertContainHint(t, completer("m"), "mkdir")
 	assertContainHint(t, completer("d"), "dump")
 	assertContainHint(t, completer("s"), "set")
 	assertContainHint(t, completer("r"), "rm")

--- a/cli/completer_test.go
+++ b/cli/completer_test.go
@@ -2,11 +2,12 @@ package cli
 
 import "testing"
 import (
-	"github.com/kamilhark/etcdsh/mocks"
-	"github.com/kamilhark/etcdsh/commands"
-	"github.com/kamilhark/etcdsh/pathresolver"
 	"strings"
+
 	"github.com/coreos/etcd/client"
+	"github.com/kamilhark/etcdsh/commands"
+	"github.com/kamilhark/etcdsh/mocks"
+	"github.com/kamilhark/etcdsh/pathresolver"
 )
 
 var keysApiMock = mocks.NewKeysApiMock()
@@ -17,6 +18,8 @@ var commandsArray = []commands.Command{
 	&commands.GetCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
 	&commands.SetCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
 	&commands.RmCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
+	&commands.RmDirCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
+	&commands.MkDirCommand{PathResolver: pathResolver, KeysApi: keysApiMock},
 	&commands.ExitCommand{},
 }
 var completer = (&Completer{keysApiMock, commandsArray, pathResolver}).Get
@@ -114,10 +117,9 @@ func assertLength(t *testing.T, slice []string, expectedLength int) {
 }
 
 func createDirNode(key string) *client.Node {
-	return &client.Node{Dir:true, Key:key}
+	return &client.Node{Dir: true, Key: key}
 }
 
 func createValueNode(key string) *client.Node {
-	return &client.Node{Dir:false, Key:key}
+	return &client.Node{Dir: false, Key: key}
 }
-

--- a/commands/cp.go
+++ b/commands/cp.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"strings"
+
+	"github.com/kamilhark/etcdsh/common"
+	"github.com/kamilhark/etcdsh/engine"
+)
+
+type CpCommand struct {
+	Engine engine.Engine
+}
+
+func (c *CpCommand) Supports(command string) bool {
+	return strings.EqualFold(command, "cp")
+}
+
+func (c *CpCommand) Handle(args []string) {
+	var srcArg = ""
+	var dstArg = ""
+	if len(args) > 0 {
+		srcArg = args[0]
+	}
+	if len(args) > 1 {
+		dstArg = args[1]
+	}
+
+	c.Engine.Cp(srcArg, dstArg)
+}
+
+func (c *CpCommand) Verify(args []string) error {
+	if len(args) > 2 {
+		return common.NewStringError("to many arguments")
+	}
+	return nil
+}
+
+func (c *CpCommand) CommandString() string {
+	return "cp"
+}
+
+func (o *CpCommand) GetAutoCompleteConfig() AutoCompleteConfig {
+	return AutoCompleteConfig{Available: true, OnlyDirs: true}
+}

--- a/commands/dump.go
+++ b/commands/dump.go
@@ -1,0 +1,62 @@
+package commands
+
+import "fmt"
+import "github.com/kamilhark/etcdsh/common"
+import "github.com/kamilhark/etcdsh/pathresolver"
+import (
+	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+)
+
+type DumpCommand struct {
+	PathResolver *pathresolver.PathResolver
+	KeysApi      client.KeysAPI
+}
+
+func (c *DumpCommand) Supports(command string) bool {
+	return command == "dump"
+}
+
+func (c *DumpCommand) Handle(args []string) {
+	var lsArg = ""
+	if len(args) == 1 {
+		lsArg = args[0]
+	}
+	lsPath := c.PathResolver.Resolve(lsArg)
+	resp, err := c.KeysApi.Get(context.Background(), lsPath, &client.GetOptions{
+		Recursive: true,
+	})
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	recurseDump(resp.Node)
+}
+
+func recurseDump(n *client.Node) {
+	if n.Dir {
+		fmt.Printf("%s/\n", n.Key)
+		for _, node := range n.Nodes {
+			recurseDump(node)
+		}
+	} else {
+		fmt.Printf("%s#%s\n", n.Key, n.Value)
+	}
+}
+
+func (c *DumpCommand) Verify(args []string) error {
+	if len(args) > 2 {
+		return common.NewStringError("to many arguments")
+	}
+	return nil
+}
+
+func (c *DumpCommand) CommandString() string {
+	return "dump"
+}
+
+func (o *DumpCommand) GetAutoCompleteConfig() AutoCompleteConfig {
+	return AutoCompleteConfig{Available: true, OnlyDirs: true}
+}

--- a/commands/dump.go
+++ b/commands/dump.go
@@ -1,38 +1,31 @@
 package commands
 
-import "fmt"
-import "github.com/kamilhark/etcdsh/common"
-import "github.com/kamilhark/etcdsh/pathresolver"
 import (
+	"fmt"
+	"strings"
+
 	"github.com/coreos/etcd/client"
-	"golang.org/x/net/context"
+	"github.com/kamilhark/etcdsh/common"
+	"github.com/kamilhark/etcdsh/engine"
 )
 
 type DumpCommand struct {
-	PathResolver *pathresolver.PathResolver
-	KeysApi      client.KeysAPI
+	Engine engine.Engine
 }
 
 func (c *DumpCommand) Supports(command string) bool {
-	return command == "dump"
+	return strings.EqualFold(command, "dump")
 }
 
 func (c *DumpCommand) Handle(args []string) {
-	var lsArg = ""
+	var dumpArg = ""
 	if len(args) == 1 {
-		lsArg = args[0]
+		dumpArg = args[0]
 	}
-	lsPath := c.PathResolver.Resolve(lsArg)
-	resp, err := c.KeysApi.Get(context.Background(), lsPath, &client.GetOptions{
-		Recursive: true,
-	})
-
-	if err != nil {
-		fmt.Println(err)
-		return
+	node := c.Engine.Get(dumpArg, true)
+	if node != nil {
+		recurseDump(node)
 	}
-
-	recurseDump(resp.Node)
 }
 
 func recurseDump(n *client.Node) {

--- a/commands/exit.go
+++ b/commands/exit.go
@@ -2,8 +2,8 @@ package commands
 
 import "os"
 import (
-	"strings"
 	"github.com/peterh/liner"
+	"strings"
 )
 
 type ExitCommand struct {
@@ -28,5 +28,5 @@ func (exitCommand *ExitCommand) CommandString() string {
 }
 
 func (o *ExitCommand) GetAutoCompleteConfig() AutoCompleteConfig {
-	return AutoCompleteConfig{Available:false}
+	return AutoCompleteConfig{Available: false}
 }

--- a/commands/get.go
+++ b/commands/get.go
@@ -1,17 +1,15 @@
 package commands
 
-import "strings"
-import "fmt"
-import "github.com/kamilhark/etcdsh/pathresolver"
 import (
+	"fmt"
+	"strings"
+
 	"github.com/kamilhark/etcdsh/common"
-	"github.com/coreos/etcd/client"
-	"golang.org/x/net/context"
+	"github.com/kamilhark/etcdsh/engine"
 )
 
 type GetCommand struct {
-	PathResolver *pathresolver.PathResolver
-	KeysApi      client.KeysAPI
+	Engine engine.Engine
 }
 
 func (c *GetCommand) Supports(command string) bool {
@@ -19,16 +17,11 @@ func (c *GetCommand) Supports(command string) bool {
 }
 
 func (c *GetCommand) Handle(args []string) {
-	key := c.PathResolver.Resolve(args[0])
-	response, err := c.KeysApi.Get(context.Background(), key, &client.GetOptions{})
-	if err != nil {
-		fmt.Println(err)
+	node := c.Engine.Get(args[0], false)
+	if node.Dir {
+		fmt.Println("dir provided, no value")
 	} else {
-		if response.Node.Dir {
-			fmt.Println("dir provided, no value")
-		} else {
-			fmt.Println(response.Node.Value)
-		}
+		fmt.Println(node.Value)
 	}
 }
 
@@ -44,7 +37,5 @@ func (c *GetCommand) CommandString() string {
 }
 
 func (o *GetCommand) GetAutoCompleteConfig() AutoCompleteConfig {
-	return AutoCompleteConfig{Available:true, OnlyDirs:false}
+	return AutoCompleteConfig{Available: true, OnlyDirs: false}
 }
-
-

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -1,20 +1,19 @@
 package commands
 
-import "fmt"
-import "github.com/kamilhark/etcdsh/common"
-import "github.com/kamilhark/etcdsh/pathresolver"
 import (
-	"github.com/coreos/etcd/client"
-	"golang.org/x/net/context"
+	"fmt"
+	"strings"
+
+	"github.com/kamilhark/etcdsh/common"
+	"github.com/kamilhark/etcdsh/engine"
 )
 
 type LsCommand struct {
-	PathResolver *pathresolver.PathResolver
-	KeysApi      client.KeysAPI
+	Engine engine.Engine
 }
 
 func (c *LsCommand) Supports(command string) bool {
-	return command == "ls"
+	return strings.EqualFold(command, "ls")
 }
 
 func (c *LsCommand) Handle(args []string) {
@@ -22,16 +21,12 @@ func (c *LsCommand) Handle(args []string) {
 	if len(args) == 1 {
 		lsArg = args[0]
 	}
-	lsPath := c.PathResolver.Resolve(lsArg)
-	resp, err := c.KeysApi.Get(context.Background(), lsPath, &client.GetOptions{})
+	node := c.Engine.Get(lsArg, true)
 
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	for _, node := range resp.Node.Nodes {
-		fmt.Println(node.Key)
+	if node != nil {
+		for _, n := range node.Nodes {
+			fmt.Println(n.Key)
+		}
 	}
 }
 
@@ -47,7 +42,5 @@ func (c *LsCommand) CommandString() string {
 }
 
 func (o *LsCommand) GetAutoCompleteConfig() AutoCompleteConfig {
-	return AutoCompleteConfig{Available:true, OnlyDirs:true}
+	return AutoCompleteConfig{Available: true, OnlyDirs: true}
 }
-
-

--- a/commands/mkdir.go
+++ b/commands/mkdir.go
@@ -1,0 +1,44 @@
+package commands
+
+import "strings"
+import "fmt"
+import "github.com/kamilhark/etcdsh/pathresolver"
+import (
+	"github.com/kamilhark/etcdsh/common"
+	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+)
+
+type MkDirCommand struct {
+	PathResolver *pathresolver.PathResolver
+	KeysApi      client.KeysAPI
+}
+
+func (c *MkDirCommand) Supports(command string) bool {
+	return strings.EqualFold(command, "mkdir")
+}
+
+func (c *MkDirCommand) Handle(args []string) {
+	key := c.PathResolver.Resolve(args[0])
+	_, err := c.KeysApi.Set(context.Background(), key, "", &client.SetOptions{Dir:true})
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func (c *MkDirCommand) Verify(args []string) error {
+	if len(args) != 1 {
+		return common.NewStringError("wrong number of arguments, mkdir command requires one argument")
+	}
+	return nil
+}
+
+func (c *MkDirCommand) CommandString() string {
+	return "mkdir"
+}
+
+func (o *MkDirCommand) GetAutoCompleteConfig() AutoCompleteConfig {
+	return AutoCompleteConfig{Available:false}
+}
+
+

--- a/commands/mkdir.go
+++ b/commands/mkdir.go
@@ -1,17 +1,14 @@
 package commands
 
 import "strings"
-import "fmt"
-import "github.com/kamilhark/etcdsh/pathresolver"
+
 import (
 	"github.com/kamilhark/etcdsh/common"
-	"github.com/coreos/etcd/client"
-	"golang.org/x/net/context"
+	"github.com/kamilhark/etcdsh/engine"
 )
 
 type MkDirCommand struct {
-	PathResolver *pathresolver.PathResolver
-	KeysApi      client.KeysAPI
+	Engine engine.Engine
 }
 
 func (c *MkDirCommand) Supports(command string) bool {
@@ -19,11 +16,7 @@ func (c *MkDirCommand) Supports(command string) bool {
 }
 
 func (c *MkDirCommand) Handle(args []string) {
-	key := c.PathResolver.Resolve(args[0])
-	_, err := c.KeysApi.Set(context.Background(), key, "", &client.SetOptions{Dir:true})
-	if err != nil {
-		fmt.Println(err)
-	}
+	c.Engine.MkDir(args[0])
 }
 
 func (c *MkDirCommand) Verify(args []string) error {
@@ -38,7 +31,5 @@ func (c *MkDirCommand) CommandString() string {
 }
 
 func (o *MkDirCommand) GetAutoCompleteConfig() AutoCompleteConfig {
-	return AutoCompleteConfig{Available:false}
+	return AutoCompleteConfig{Available: false}
 }
-
-

--- a/commands/mv.go
+++ b/commands/mv.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"strings"
+
+	"github.com/kamilhark/etcdsh/common"
+	"github.com/kamilhark/etcdsh/engine"
+)
+
+type MvCommand struct {
+	Engine engine.Engine
+}
+
+func (c *MvCommand) Supports(command string) bool {
+	return strings.EqualFold(command, "mv")
+}
+
+func (c *MvCommand) Handle(args []string) {
+	var srcArg = ""
+	var dstArg = ""
+	if len(args) > 0 {
+		srcArg = args[0]
+	}
+	if len(args) > 1 {
+		dstArg = args[1]
+	}
+
+	c.Engine.Mv(srcArg, dstArg)
+}
+
+func (c *MvCommand) Verify(args []string) error {
+	if len(args) > 2 {
+		return common.NewStringError("to many arguments")
+	}
+	return nil
+}
+
+func (c *MvCommand) CommandString() string {
+	return "mv"
+}
+
+func (o *MvCommand) GetAutoCompleteConfig() AutoCompleteConfig {
+	return AutoCompleteConfig{Available: true, OnlyDirs: true}
+}

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -1,17 +1,14 @@
 package commands
 
 import "strings"
-import "fmt"
-import "github.com/kamilhark/etcdsh/pathresolver"
+
 import (
 	"github.com/kamilhark/etcdsh/common"
-	"github.com/coreos/etcd/client"
-	"golang.org/x/net/context"
+	"github.com/kamilhark/etcdsh/engine"
 )
 
 type RmCommand struct {
-	PathResolver *pathresolver.PathResolver
-	KeysApi      client.KeysAPI
+	Engine engine.Engine
 }
 
 func (c *RmCommand) Supports(command string) bool {
@@ -20,11 +17,7 @@ func (c *RmCommand) Supports(command string) bool {
 
 func (c *RmCommand) Handle(args []string) {
 	for i := 0; i < len(args); i++ {
-		key := c.PathResolver.Resolve(args[i])
-		_, err := c.KeysApi.Delete(context.Background(), key, &client.DeleteOptions{})
-		if err != nil {
-			fmt.Println(err)
-		}
+		c.Engine.Rm(args[i], false)
 	}
 }
 
@@ -40,6 +33,5 @@ func (c *RmCommand) CommandString() string {
 }
 
 func (o *RmCommand) GetAutoCompleteConfig() AutoCompleteConfig {
-	return AutoCompleteConfig{Available:true, OnlyDirs:false}
+	return AutoCompleteConfig{Available: true, OnlyDirs: false}
 }
-

--- a/commands/rmdir.go
+++ b/commands/rmdir.go
@@ -1,0 +1,45 @@
+package commands
+
+import "strings"
+import "fmt"
+import "github.com/kamilhark/etcdsh/pathresolver"
+import (
+	"github.com/kamilhark/etcdsh/common"
+	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+)
+
+type RmDirCommand struct {
+	PathResolver *pathresolver.PathResolver
+	KeysApi      client.KeysAPI
+}
+
+func (c *RmDirCommand) Supports(command string) bool {
+	return strings.EqualFold(command, "rmdir")
+}
+
+func (c *RmDirCommand) Handle(args []string) {
+	for i := 0; i < len(args); i++ {
+		key := c.PathResolver.Resolve(args[i])
+		_, err := c.KeysApi.Delete(context.Background(), key, &client.DeleteOptions{Recursive: true, Dir: true})
+		if err != nil {
+			fmt.Println(err)
+		}
+	}
+}
+
+func (c *RmDirCommand) Verify(args []string) error {
+	if len(args) < 1 {
+		return common.NewStringError("wrong number of arguments, rm command requires at least one argument")
+	}
+	return nil
+}
+
+func (c *RmDirCommand) CommandString() string {
+	return "rmdir"
+}
+
+func (o *RmDirCommand) GetAutoCompleteConfig() AutoCompleteConfig {
+	return AutoCompleteConfig{Available:true, OnlyDirs:true}
+}
+

--- a/commands/rmdir.go
+++ b/commands/rmdir.go
@@ -1,17 +1,14 @@
 package commands
 
 import "strings"
-import "fmt"
-import "github.com/kamilhark/etcdsh/pathresolver"
+
 import (
 	"github.com/kamilhark/etcdsh/common"
-	"github.com/coreos/etcd/client"
-	"golang.org/x/net/context"
+	"github.com/kamilhark/etcdsh/engine"
 )
 
 type RmDirCommand struct {
-	PathResolver *pathresolver.PathResolver
-	KeysApi      client.KeysAPI
+	Engine engine.Engine
 }
 
 func (c *RmDirCommand) Supports(command string) bool {
@@ -20,11 +17,7 @@ func (c *RmDirCommand) Supports(command string) bool {
 
 func (c *RmDirCommand) Handle(args []string) {
 	for i := 0; i < len(args); i++ {
-		key := c.PathResolver.Resolve(args[i])
-		_, err := c.KeysApi.Delete(context.Background(), key, &client.DeleteOptions{Recursive: true, Dir: true})
-		if err != nil {
-			fmt.Println(err)
-		}
+		c.Engine.Rm(args[i], true)
 	}
 }
 
@@ -40,6 +33,5 @@ func (c *RmDirCommand) CommandString() string {
 }
 
 func (o *RmDirCommand) GetAutoCompleteConfig() AutoCompleteConfig {
-	return AutoCompleteConfig{Available:true, OnlyDirs:true}
+	return AutoCompleteConfig{Available: true, OnlyDirs: true}
 }
-

--- a/commands/set.go
+++ b/commands/set.go
@@ -1,17 +1,14 @@
 package commands
 
-import "strings"
-import "fmt"
-import "github.com/kamilhark/etcdsh/pathresolver"
 import (
+	"strings"
+
 	"github.com/kamilhark/etcdsh/common"
-	"github.com/coreos/etcd/client"
-	"golang.org/x/net/context"
+	"github.com/kamilhark/etcdsh/engine"
 )
 
 type SetCommand struct {
-	PathResolver *pathresolver.PathResolver
-	KeysApi      client.KeysAPI
+	Engine engine.Engine
 }
 
 func (c *SetCommand) Supports(command string) bool {
@@ -19,12 +16,7 @@ func (c *SetCommand) Supports(command string) bool {
 }
 
 func (c *SetCommand) Handle(args []string) {
-	key := c.PathResolver.Resolve(args[0])
-	value := args[1]
-	_, err := c.KeysApi.Set(context.Background(), key, value, &client.SetOptions{Dir:false})
-	if err != nil {
-		fmt.Println(err)
-	}
+	c.Engine.Set(args[0], args[1])
 }
 
 func (c *SetCommand) Verify(args []string) error {
@@ -39,7 +31,5 @@ func (c *SetCommand) CommandString() string {
 }
 
 func (o *SetCommand) GetAutoCompleteConfig() AutoCompleteConfig {
-	return AutoCompleteConfig{Available:true, OnlyDirs:true}
+	return AutoCompleteConfig{Available: true, OnlyDirs: true}
 }
-
-

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -1,0 +1,82 @@
+package engine
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+
+	"github.com/kamilhark/etcdsh/pathresolver"
+)
+
+type Engine struct {
+	PathResolver *pathresolver.PathResolver
+	KeysApi      client.KeysAPI
+}
+
+func (e *Engine) ResolvePath(subPath string) string {
+	return e.PathResolver.Resolve(subPath)
+}
+
+func (e *Engine) Set(key string, value string) {
+	key = e.ResolvePath(key)
+	_, err := e.KeysApi.Set(context.Background(), key, value, &client.SetOptions{Dir: false})
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func (e *Engine) Get(key string, recursive bool) *client.Node {
+	key = e.ResolvePath(key)
+	response, err := e.KeysApi.Get(context.Background(), key, &client.GetOptions{Recursive: recursive})
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		return response.Node
+	}
+	return nil
+}
+
+func (e *Engine) MkDir(key string) {
+	key = e.ResolvePath(key)
+	_, err := e.KeysApi.Set(context.Background(), key, "", &client.SetOptions{Dir: true})
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func (e *Engine) Rm(key string, recursive bool) {
+	key = e.ResolvePath(key)
+	_, err := e.KeysApi.Delete(context.Background(), key, &client.DeleteOptions{Recursive: recursive})
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func (e *Engine) Cp(srcPath string, dstPath string) {
+	srcPath = e.ResolvePath(srcPath)
+	dstPath = e.ResolvePath(dstPath)
+
+	node := e.Get(srcPath, true)
+	if node != nil {
+		e.recurseCp(node, srcPath, dstPath)
+	}
+}
+
+func (e *Engine) Mv(srcPath string, dstPath string) {
+	e.Cp(srcPath, dstPath)
+	e.Rm(srcPath, true)
+}
+
+func (e *Engine) recurseCp(n *client.Node, srcPath string, dstPath string) {
+	newKey := strings.Replace(n.Key, srcPath, dstPath, 1)
+	if n.Dir {
+		e.MkDir(newKey)
+		for _, node := range n.Nodes {
+			e.recurseCp(node, srcPath, dstPath)
+		}
+	} else {
+		e.Set(newKey, n.Value)
+	}
+}

--- a/mocks/keysapimock.go
+++ b/mocks/keysapimock.go
@@ -2,7 +2,8 @@ package mocks
 
 import (
 	"github.com/coreos/etcd/client"
-	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	//	"github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
+	"golang.org/x/net/context"
 )
 
 type KeysApiMock struct {
@@ -10,7 +11,7 @@ type KeysApiMock struct {
 }
 
 func NewKeysApiMock() *KeysApiMock {
-	return &KeysApiMock{mockedGetMethodInvocations:make(map[string]*client.Response)}
+	return &KeysApiMock{mockedGetMethodInvocations: make(map[string]*client.Response)}
 }
 
 func (mock *KeysApiMock) Get(ctx context.Context, key string, opts *client.GetOptions) (*client.Response, error) {

--- a/pathresolver/pathresolver.go
+++ b/pathresolver/pathresolver.go
@@ -7,6 +7,11 @@ type PathResolver struct {
 }
 
 func (p *PathResolver) Resolve(subPath string) string {
+
+	if len(subPath) > 0 && subPath[0] == '/' {
+		return subPath
+	}
+
 	elements := strings.Split(subPath, "/")
 
 	currentPath := new(PathResolver)
@@ -43,7 +48,7 @@ func (p *PathResolver) Clear() {
 
 func (p *PathResolver) RemoveLast() {
 	if len(p.path) > 0 {
-		p.path = p.path[:len(p.path) - 1]
+		p.path = p.path[:len(p.path)-1]
 	}
 }
 
@@ -59,7 +64,7 @@ func normalize(path string) string {
 		path = "/" + path
 	}
 	if strings.HasSuffix(path, "/") {
-		path = path[:len(path) - 1]
+		path = path[:len(path)-1]
 	}
 	return path
 }


### PR DESCRIPTION
 - It was included the '-urls [urls separated by comma]' parameter to support ETCD Cluster
- The command 'mkdir ' was implemented
- The command 'rmdir ' was implemented (recursive)